### PR TITLE
Update plugin.php to nuse new license keys with underscores

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -100,7 +100,7 @@ function ozh_yourls_geoupd_update_db() {
 
 // Sanitize the api key
 function ozh_yourls_sanitize_api_key( $key ) {
-    return preg_replace('/[^a-zA-Z0-9]/', '', $key);
+    return preg_replace('/[^a-zA-Z0-9_]/', '', $key);
 }
 
 // Echo last modified date of the database on Maxmind server


### PR DESCRIPTION
It looks like the licence key format has changed to include underscores, and the underscores are currently being sanitised from the input. The fix is to update line 103 of plugin.php.
_Originally posted by @fezzzza in https://github.com/ozh/yourls-geoip-update/issues/4#issuecomment-1530142904_